### PR TITLE
Cargo assumes network access is always available

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The Licence for this repo is [CC0](https://creativecommons.org/publicdomain/zero
 
 ### Cabal
 
+### Cargo
+
+* Assumes build machine is networked; no obvious way to pre-download dependencies and have them be used
+
 ### CMake
 
 * Custom language


### PR DESCRIPTION
Probably there is _some_ way to hack cargo to make this work, but I have never managed to find out.